### PR TITLE
feat: Better typings

### DIFF
--- a/src/MultiStoreController.ts
+++ b/src/MultiStoreController.ts
@@ -1,5 +1,5 @@
 import { ReactiveController, ReactiveControllerHost } from "lit";
-import { WritableAtom } from "nanostores";
+import { Store } from "nanostores";
 
 /**
  * A `ReactiveController` that subscribes a `LitElement` to several `nanostores` atoms and updates the host element when any of the atoms changes.
@@ -25,7 +25,7 @@ import { WritableAtom } from "nanostores";
  * ```
  */
 export class MultiStoreController<
-  TAtoms extends [] | ReadonlyArray<WritableAtom<unknown>>
+  TAtoms extends [] | ReadonlyArray<Store<unknown>>
 > implements ReactiveController
 {
   private unsubscribes: undefined | (() => void)[];
@@ -54,6 +54,6 @@ export class MultiStoreController<
     [K in keyof TAtoms]: ReturnType<TAtoms[K]["get"]>;
   } {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    return this.atoms.map(<T>(atom: WritableAtom<T>) => atom.get()) as any;
+    return this.atoms.map(<T>(atom: Store<T>) => atom.get()) as any;
   }
 }

--- a/src/StoreController.ts
+++ b/src/StoreController.ts
@@ -1,5 +1,5 @@
 import { ReactiveController, ReactiveControllerHost } from "lit";
-import { WritableAtom } from "nanostores";
+import { Store } from "nanostores";
 
 /**
  * A `ReactiveController` that subscribes a `LitElement` to a `nanostores` atom and updates the host element when the atom changes.
@@ -28,7 +28,7 @@ export class StoreController<AtomType> implements ReactiveController {
 
   constructor(
     private host: ReactiveControllerHost,
-    private atom: WritableAtom<AtomType>
+    private atom: Store<AtomType>
   ) {
     host.addController(this);
   }

--- a/src/useStores.ts
+++ b/src/useStores.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { ReactiveControllerHost } from "lit";
-import { WritableAtom } from "nanostores";
+import { Store } from "nanostores";
 import { MultiStoreController } from "./MultiStoreController";
 
 /**
@@ -26,7 +26,7 @@ import { MultiStoreController } from "./MultiStoreController";
  * }
  * ```
  */
-export function useStores<TAtoms extends Array<WritableAtom<unknown>>>(
+export function useStores<TAtoms extends Array<Store<unknown>>>(
   ...atoms: TAtoms
 ) {
   return <TConstructor extends new (...args: any[]) => ReactiveControllerHost>(

--- a/src/withStores.ts
+++ b/src/withStores.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { LitElement } from "lit";
-import { WritableAtom } from "nanostores";
+import { Store } from "nanostores";
 import { MultiStoreController } from "./MultiStoreController";
 
 /**
@@ -28,7 +28,7 @@ import { MultiStoreController } from "./MultiStoreController";
  */
 export const withStores = <
   TLitElementClass extends new (...args: any[]) => LitElement,
-  TAtoms extends Array<WritableAtom<unknown>>
+  TAtoms extends Array<Store<unknown>>
 >(
   LitElementClass: TLitElementClass,
   atoms: TAtoms


### PR DESCRIPTION
Using `nanostores/router` didn't work because I expected all atoms to be of type `WritableAtom`. That should work now. (closes #2).   @ai can you confirm that `Store` is the right type to be using here?  I checked this work with `nanostores/router` and I checked `nanostores/solid` and saw that was what is used there.