### PR TITLE
Loosen `nanostores` peer dependency up a little…

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "postversion": "git push && git push --tags"
   },
   "peerDependencies": {
-    "nanostores": "^0.7.1",
+    "nanostores": "^0.7 || ^0.8",
     "lit": "^2.6.0"
   },
   "devDependencies": {


### PR DESCRIPTION
To use other `nanostores` packages (e.g. https://github.com/nanostores/persistent), the peer dependency needs to include the latest `0.8.x` version.

Looking at the changelog in the main packages, this should be safe.