### PR TITLE
Fix syntax issue in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "postversion": "git push && git push --tags"
   },
   "peerDependencies": {
-    "nanostores": "^0.7 || ^0.8 || ^0.9 || ^0.10" || "^0.11",
+    "nanostores": "^0.7 || ^0.8 || ^0.9 || ^0.10 || ^0.11",
     "lit": "^2.6.0 || ^3.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
The update to support the latest peerDep broke the JSON.